### PR TITLE
Sending commands to device

### DIFF
--- a/philips/message.go
+++ b/philips/message.go
@@ -41,7 +41,7 @@ func ParseID(data []byte) SessionID {
 
 // NewID constructs a new valid SessionID
 func NewID() SessionID {
-	return SessionID(rnd.Uint32())
+	return SessionID(rnd.Int31())
 }
 
 // Hex returns the hex representation of our SessionID


### PR DESCRIPTION
Quick hack to show how commands can be sent to the device

Also changes the `NewID()` method to use `rand.Int31()` instead of `Uint32()` to avoid overflowing the counter